### PR TITLE
fix: 修复链接中包含多个参数时`rid`解析失败

### DIFF
--- a/web/WaWaJiWeb/src/entry/dynamic/wawaji/_play.js
+++ b/web/WaWaJiWeb/src/entry/dynamic/wawaji/_play.js
@@ -129,7 +129,8 @@ if (!localIdName) {
 nickName = "u" + idName;
 
 //获取房间id
-roomID = window.location.search.slice(1).split('=')[1];
+roomID = window.location.search.match(/rid=(\w+)?/);
+roomID = roomID ? roomID[1] : '';
 console.log('roomid = ', roomID, '\n');
 
 


### PR DESCRIPTION
例如：[http://wwj.zego.im/wawaji/index.html?rid=WWJ_ZEGO_32a03dd42e06&key=1](http://wwj.zego.im/wawaji/index.html?rid=WWJ_ZEGO_32a03dd42e06&key=1)

多个参数会导致`window.location.search.slice(1).split('=')[1]`的执行无法获取到预期结果。